### PR TITLE
Ensuring ability for reentry

### DIFF
--- a/gauss.js
+++ b/gauss.js
@@ -16,56 +16,74 @@ function array_fill(i, n, v) {
  */
 function gauss(A, x) {
 
-    var i, k, j;
+      //Laufvariablen
+      var i, k, j;
+
+      var A_copy=[];
+      var x_copy=[];
+
+      //Kopie von A anlegen
+      for (var i=0; i<A.length; ++i)
+      {
+        A_copy[i] = A[i].slice();
+      }
+
+      //Kopie von b anlegen
+      for (var i=0; i<x.length; ++i)
+      {
+        x_copy[i] = x[i];
+      }
+
+
 
     // Just make a single matrix
-    for (i=0; i < A.length; i++) { 
-        A[i].push(x[i]);
+    for (i=0; i < A_copy.length; i++) {
+        A_copy[i].push(x_copy[i]);
     }
-    var n = A.length;
+    var n = A_copy.length;
 
-    for (i=0; i < n; i++) { 
+    for (i=0; i < n; i++) {
         // Search for maximum in this column
-        var maxEl = abs(A[i][i]),
+        var maxEl = abs(A_copy[i][i]),
             maxRow = i;
-        for (k=i+1; k < n; k++) { 
-            if (abs(A[k][i]) > maxEl) {
-                maxEl = abs(A[k][i]);
+        for (k=i+1; k < n; k++) {
+            if (abs(A_copy[k][i]) > maxEl) {
+                maxEl = abs(A_copy[k][i]);
                 maxRow = k;
             }
         }
 
 
         // Swap maximum row with current row (column by column)
-        for (k=i; k < n+1; k++) { 
-            var tmp = A[maxRow][k];
-            A[maxRow][k] = A[i][k];
-            A[i][k] = tmp;
+        for (k=i; k < n+1; k++) {
+            var tmp = A_copy[maxRow][k];
+            A_copy[maxRow][k] = A_copy[i][k];
+            A_copy[i][k] = tmp;
         }
 
         // Make all rows below this one 0 in current column
-        for (k=i+1; k < n; k++) { 
-            var c = -A[k][i]/A[i][i];
-            for (j=i; j < n+1; j++) { 
+        for (k=i+1; k < n; k++) {
+            var c = -A_copy[k][i]/A_copy[i][i];
+            for (j=i; j < n+1; j++) {
                 if (i===j) {
-                    A[k][j] = 0;
+                    A_copy[k][j] = 0;
                 } else {
-                    A[k][j] += c * A[i][j];
+                    A_copy[k][j] += c * A_copy[i][j];
                 }
             }
         }
     }
 
     // Solve equation Ax=b for an upper triangular matrix A
-    x = array_fill(0, n, 0);
-    for (i=n-1; i > -1; i--) { 
-        x[i] = A[i][n]/A[i][i];
-        for (k=i-1; k > -1; k--) { 
-            A[k][n] -= A[k][i] * x[i];
+    x_copy = array_fill(0, n, 0);
+    for (i=n-1; i > -1; i--) {
+        x_copy[i] = A_copy[i][n]/A_copy[i][i];
+        for (k=i-1; k > -1; k--) {
+            A_copy[k][n] -= A_copy[k][i] * x_copy[i];
         }
     }
 
-    return x;
+    return x_copy;
 }
 
 module.exports = gauss;

--- a/gauss.js
+++ b/gauss.js
@@ -16,19 +16,19 @@ function array_fill(i, n, v) {
  */
 function gauss(A, x) {
 
-      //Laufvariablen
+      //Index variables
       var i, k, j;
 
       var A_copy=[];
       var x_copy=[];
 
-      //Kopie von A anlegen
+      //Copy A
       for (var i=0; i<A.length; ++i)
       {
         A_copy[i] = A[i].slice();
       }
 
-      //Kopie von b anlegen
+      //Copy b
       for (var i=0; i<x.length; ++i)
       {
         x_copy[i] = x[i];


### PR DESCRIPTION
**Problem description**

Your implementation of gaussian elimination fails for integration in e.g. Newton algorithm, because it's not able to reentry.
Try following:

`    $A = [[1, 1, 1], [2, 1, 2], [1, 2, 3]];
    $x = [6, 10, 14];
    $result = gauss($A, $x);
    console.log($result);
    $result = gauss($A, $x);
    console.log($result);
    $result = gauss($A, $x);`

You get 3 different solutions because A and x are changed every time we call gauss. The problem is that you give the variables over Call by Reference to the algorithm.

**My pull request**

Let us copy A and x (I called it b) at the beginning of the algorithm.